### PR TITLE
Samsvar mellom doc i README og help-kommandoen

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ should be pulled. Specified using the `--version` flag
 
 The most basic deployment should look something like:
                                                                                    
-`deployment-cli create --cluster=dev-fss --repository=navikt/deployment --team=<team> --version=1.0.0 --appid=1234 --key=/path/to/private-key.pem --resource=nais.yaml --vars=placeholders.json`
+`deployment-cli deploy create --environment=dev-fss --repository=navikt/deployment --team=<team> --version=1.0.0 --appid=1234 --key=/path/to/private-key.pem --resource=nais.yaml --config=placeholders.json`
                                                                                    
 Note: For deployments using github apps the private key has to be pem encoded.
 


### PR DESCRIPTION
Oppdaterer i henhold til output fra kjøring av "docker run -it navikt/deployment-cli deployment-cli help deploy create"