### PR TITLE
Set a higher poll interval

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -197,7 +197,7 @@ pub fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
                 .arg(Arg::with_name("poll-interval")
                     .long("poll-interval")
                     .help("Specifies the interval in ms used for polling while awaiting a github status update")
-                    .default_value("1000")
+                    .default_value("5000")
                     .required(true))))
 
             .subcommand(SubCommand::with_name("payload")


### PR DESCRIPTION
Some workflows are having issues with rate limits, so setting a higher poll interval should help. Rate limits for the autogenerated `GITHUB_TOKEN` does not reset after a workflow run, so repos that try to deploy rapidly will quickly hit the limit.